### PR TITLE
fix(pyproject): app name in pyproject.toml 

### DIFF
--- a/{{cookiecutter.repo_name}}/pyproject.toml
+++ b/{{cookiecutter.repo_name}}/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.poetry]
-name = "app"
+name = "{{cookiecutter.repo_name}}"
 version = "0.1.0"
 description = ""
 authors = ["User <user@example.com>"]


### PR DESCRIPTION
impacts virtualenv name, fix it to be based on the repo's name to avoid future conflicts