### PR TITLE
Update poetry install cmd

### DIFF
--- a/{{cookiecutter.repo_name}}/README.md
+++ b/{{cookiecutter.repo_name}}/README.md
@@ -20,11 +20,13 @@ To set up and run the app, please follow these steps:
    ```shell
    poetry install
    ```
-   If you also want to install development packages,
+
+   If you don't want to install the dev packages,
    you can use the following command instead:
    ```shell
-   poetry install --with dev
+   poetry install --without dev
    ```
+
 3. Activate the virtual environment:
 
    ```shell


### PR DESCRIPTION
Hi, thanks for sharing this cool project, I'm currently using it as the base for a new fastapi/sqlalchemy project. It will for sure let me gain a great amount of time instead of copy/pasting my old project.

Just a little nit here, according to the [poetry documentation](https://python-poetry.org/docs/cli/#install) and from what I experienced 2 minutes ago 🤗 :
* The dev packages are installed by default when running the command `poetry install`
* In order to install only the main packages, the command is `poetry install --without dev`